### PR TITLE
Get_config_path uses os.path.join (resolves #5)

### DIFF
--- a/utils/settings.py
+++ b/utils/settings.py
@@ -33,6 +33,5 @@ def get_config_path():
     """
     Return the settings path.
     """
-    path = '{0}/{1}'.format(os.path.expanduser('~'),
-                            configs.SETTINGS_FILE_NAME)
+    path = os.path.join(os.path.expanduser('~'), configs.SETTINGS_FILE_NAME)
     return os.path.normpath(path)


### PR DESCRIPTION
Changes get_config_path function in utils/settings.py to use
os.path.join as opposed to .format(). This allows for cross-OS
compatibility.

Tests will still need to be implemented as the #5 is unclear on what
changes are needed.