### PR TITLE
[Utils] Add loadSettings

### DIFF
--- a/utils/settings.py
+++ b/utils/settings.py
@@ -3,6 +3,8 @@ import json
 import os.path
 from constants import configs
 
+_settings = {}
+
 
 def config_exists():
     """
@@ -36,3 +38,15 @@ def get_config_path():
     path = '{0}/{1}'.format(os.path.expanduser('~'),
                             configs.SETTINGS_FILE_NAME)
     return os.path.normpath(path)
+
+
+def load_settings():
+    """
+    Load current settings.
+    """
+    global _settings
+
+    with open(get_config_path(), 'r+') as file:
+        _settings = json.load(file)
+
+    return _settings


### PR DESCRIPTION
## Changes
- Adds `loadSettings` method.
- Adds global `_settings` to store aforementioned settings in the `settings` module.
- Update `settings` module tests to grab `utils.settings` as a whole module.

Once this is in, we can implement middleware and actually connect to the Medium api.

![](https://media.giphy.com/media/Tld8USHlpopYA/giphy.gif)
