### PR TITLE
[Readme] Deprecate Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Jazz Dragon
 ===========
 
-# Due to limitations with Medium's API, this repo will no longer be actively maintained
-# unless said functionality is added.
+### Due to limitations with Medium's API, this repo will no longer be actively maintained unless said functionality is added.
 
 More information here: https://github.com/emmabukacek/jazz-dragon/issues/9
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 Jazz Dragon
 ===========
+
+# Due to limitations with Medium's API, this repo will no longer be actively maintained
+# unless said functionality is added.
+
+More information here: https://github.com/emmabukacek/jazz-dragon/issues/9
+
 [![Build Status](https://travis-ci.org/emmabukacek/jazz-dragon.svg?branch=develop)](https://travis-ci.org/emmabukacek/jazz-dragon)
 [![Coverage Status](https://coveralls.io/repos/github/emmabukacek/jazz-dragon/badge.svg?branch=develop)](https://coveralls.io/github/emmabukacek/jazz-dragon?branch=develop)
 
@@ -14,7 +20,6 @@ $ virtualenv venv
 $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ python setup.py develop
-$ deactivate
 ```
 
 Give it a try!


### PR DESCRIPTION
## Issues
* https://github.com/emmabukacek/jazz-dragon/issues/9
* Not that there was active development, but this officially deprecates the repo given a lack
  of required functionality from the Medium API.

## Changes
* Update README to deprecate repo.
* Remove one step from setup process.

![](https://media.giphy.com/media/GRTLIhvNNQ11K/giphy.gif)